### PR TITLE
README: fix link to KiCAD homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains the schematics and PCB design files for the MOD Dwarf hardware.
 
-These files were created and can be improved with KiCAD, a free software Electronics CAD which is available at http://www.kicad-pcb.org/
+These files were created and can be improved with KiCAD, a free software Electronics CAD which is available at http://www.kicad.org/
 
 This project should work with last revision of KiCad libraries and footprints available at https://github.com/KiCad/


### PR DESCRIPTION
The current link goes to some questionable site which has nothing to do with KiCAD.